### PR TITLE
Implement metaclass based approach (fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ my_class.z = 'z2'
 That's it. There us no need to use `@property`.  
 'w', 'x', and 'y' are now readonly attributes. If we try to change them, `AttributeError` exception will be raised.  
 Since 'z' is not listed in `ro_attrs`, `self.z` is a mutable instance attribute.
+
+Alternatively, you can also define it as follows:
+
+```python
+from roa import ReadOnlyType
+
+class MyClass(metaclass=ReadOnlyType):
+    __ro_attrs__ = ('w', 'x', 'y')
+
+    w = 'w1'
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+```

--- a/README.md
+++ b/README.md
@@ -37,36 +37,40 @@ Like as below
 The above can be written like so which is much less verbose and lot more explicit:
 
 ```
-@read_only_attributes('x','y','z','w')
-class MyClass:
+class MyClass(metaclass=ReadOnlyType, ro_attrs=('x', 'y', 'z', 'w')):
     def __init__(self, x, y, z, w):
-        self.x = x 
-        self.y = y 
-        self.z = z 
-        self.w = w 
+        self.x = x
+        self.y = y
+        self.z = z
+        self.w = w
 ```
 
-Once the instance attributes are assigned in the __\__init____, they cannot be changed. Trying to change them will raise an `AttributeError`.
+Once the instance attributes are assigned for the first time in the __\__init____, they cannot be changed. Trying to change them will raise an `AttributeError`.
 
 Installation:
 --------------
-pipenv install read-only-properties
+pipenv install read-only-attributes
 
 Usage:
 ------
 
-import class decorator @read_only_attributes and use like so:
+import metaclass `ReadOnlyType` and use like so:
 
 ```
-from roa import read_only_attributes
+from roa import ReadOnlyType
 
-@read_only_attributes('x', 'y')
-class MyClass:
+class MyClass(metaclass=ReadOnlyType, ro_attrs=('w', 'x', 'y')):
+    w = 'w1'
     def __init__(self, x, y, z):
         self.x = x
         self.y = y
         self.z = z
+
+my_class = MyClass('x1', 'y1', 'z1')
+print(my_class.w, my_class.x, my_class.y, my_class.z)
+my_class.z = 'z2'
+# my_class.x = 'x2'  # AttributeError!
 ```
 That's it. There us no need to use `@property`.  
-'x' and 'y' are now readonly attributes. If we try to change them, `AttributeError` exception will be raised.  
-Since 'z' is not in decorator argument list, `self.z` is a mutable instance attribute.
+'w', 'x', and 'y' are now readonly attributes. If we try to change them, `AttributeError` exception will be raised.  
+Since 'z' is not listed in `ro_attrs`, `self.z` is a mutable instance attribute.

--- a/roa/__init__.py
+++ b/roa/__init__.py
@@ -1,1 +1,1 @@
-from .read_only_attributes import read_only_attributes
+from .read_only_attributes import ReadOnlyType

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 setup(
     name='read-only-attributes',         # How you named your package folder (MyLib)
     packages=['roa'],   # Chose the same as "name"
-    version='2.0',      # Start with a small number and increase it with every change you make
+    version='2.0.0',      # Start with a small number and increase it with every change you make
     license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     description='Makes read only attributes for a Python class',   # Give a short description about your library
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 setup(
     name='read-only-attributes',         # How you named your package folder (MyLib)
     packages=['roa'],   # Chose the same as "name"
-    version='1.2',      # Start with a small number and increase it with every change you make
+    version='2.0',      # Start with a small number and increase it with every change you make
     license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
     description='Makes read only attributes for a Python class',   # Give a short description about your library
     long_description=long_description,

--- a/tests/test_read_only_attributes.py
+++ b/tests/test_read_only_attributes.py
@@ -1,4 +1,5 @@
 import pytest
+
 from roa import ReadOnlyType
 
 
@@ -42,3 +43,24 @@ def test_attribute_mutable():
     assert mc.y == 2
     mc.y = 3
     assert mc.y == 3
+
+
+def test_invalid_class():
+    with pytest.raises(RuntimeError):
+
+        class MyClass(metaclass=ReadOnlyType):
+            pass
+
+
+@pytest.mark.parametrize("ro_attrs", ["val", ("val",), ["val"]])
+def test_arg_pass_methods(ro_attrs):
+    class MyClass(metaclass=ReadOnlyType):
+        __ro_attrs__ = ro_attrs
+
+        def __init__(self):
+            self.val = "v1"
+
+    mc = MyClass()
+    assert mc.val == "v1"
+    with pytest.raises(AttributeError):
+        mc.val = "v2"

--- a/tests/test_read_only_attributes.py
+++ b/tests/test_read_only_attributes.py
@@ -1,24 +1,44 @@
 import pytest
-from roa import read_only_attributes
+from roa import ReadOnlyType
 
 
 def test_attribute_immutable_error():
-    @read_only_attributes("x")
-    class MyClass:
+    class MyClass(metaclass=ReadOnlyType, ro_attrs=["x"]):
         def __init__(self, x):
             self.x = x
 
     mc = MyClass(1)
+    assert mc.x == 1
     with pytest.raises(AttributeError):
         mc.x = 3
 
 
+def test_attribute_immutable_error_static():
+    class MyClass(metaclass=ReadOnlyType, ro_attrs=["x"]):
+        x = 1
+
+    mc = MyClass()
+    assert mc.x == 1
+    with pytest.raises(AttributeError):
+        mc.x = 3
+
+
+def test_attribute_not_set_error():
+    class MyClass(metaclass=ReadOnlyType, ro_attrs=["x"]):
+        def __init__(self, x):
+            pass
+
+    with pytest.raises(RuntimeError):
+        MyClass(1)
+
+
 def test_attribute_mutable():
-    @read_only_attributes("x")
-    class MyClass:
+    class MyClass(metaclass=ReadOnlyType, ro_attrs=["x"]):
         def __init__(self, x, y):
             self.x = x
+            self.y = y
 
     mc = MyClass(1, 2)
+    assert mc.y == 2
     mc.y = 3
     assert mc.y == 3


### PR DESCRIPTION
This changes the implementation of this library to use a metaclass which fixes #8. This approach is advantageous because:

 - No new modified class is created
 - No runtime overhead occurs for non-read-only attributes

See the modified readme for more usage details. The new usage is:

```python
from roa import ReadOnlyType

class MyClass(metaclass=ReadOnlyType, ro_attrs=('w', 'x')):
    w = 'w1'
    def __init__(self, x, y):
        self.x = x
        self.y = y
```

Note: I've also included two commits to increment the version and change to [semantic versioning](https://semver.org/) but feel free to let me know and I can remove these to just include the metaclass change.